### PR TITLE
Use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Codecademy/eslint-plugin-jest-react.git"
+    "url": "git+https://github.com/Codecademy/eslint-plugin-jest-react.git"
   },
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
## Summary

- Update the package repository metadata to use the canonical HTTPS GitHub URL.
- Keep the repository target unchanged: `Codecademy/eslint-plugin-jest-react`.

## Why

The current `git@github.com:` repository URL requires SSH handling. The HTTPS form is easier for package consumers, scanners, and registry tooling to resolve without SSH configuration.

## Validation

- `node -e "const p=require('./package.json'); if (p.repository.url !== 'git+https://github.com/Codecademy/eslint-plugin-jest-react.git') process.exit(1); console.log(p.repository.url)"`
- `git diff --check`
- `git ls-remote https://github.com/Codecademy/eslint-plugin-jest-react.git HEAD`
- `yarn install --frozen-lockfile --ignore-scripts`
- `yarn compile`
- `yarn format:verify`
- `yarn lint`
- `yarn test:ci`
- `npm pack --dry-run`
