### PR TITLE
chore: use HTTPS repository metadata

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git@github.com:Codecademy/eslint-plugin-jest-react.git"
+    "url": "git+https://github.com/Codecademy/eslint-plugin-jest-react.git"
   },
   "scripts": {
     "compile": "tsc",


### PR DESCRIPTION
## Summary
- update the package repository URL from the SSH form to the public HTTPS Git URL
- keep the repository type and package metadata otherwise unchanged

## Validation
- node package metadata assertion
- git diff --check
- git ls-remote https://github.com/Codecademy/eslint-plugin-jest-react.git HEAD
- yarn install --frozen-lockfile --ignore-scripts
- yarn compile
- yarn lint
- yarn test:ci
- yarn format:verify
- yarn pack (Yarn 1 writes a temporary tarball; removed after verification)